### PR TITLE
disable gradle tests in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ FROM gradle:7-jdk17 as java-builder
 WORKDIR /project
 COPY --chown=gradle:gradle . .
 RUN --mount=type=cache,target=/gradle-cache \
-    gradle build --no-daemon --build-cache --parallel --project-cache-dir /gradle-cache
+    gradle build \
+      --no-daemon \
+      --build-cache \
+      --parallel \
+      --project-cache-dir /gradle-cache \
+      --exclude-task test
 
 FROM eclipse-temurin:17-jre
 RUN useradd -m -d /app peerrequest


### PR DESCRIPTION
Some tests require docker containers but docker is not available in docker build